### PR TITLE
tooling: Add mise/uv/freeze requirements

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,47 @@
+[tools]
+python = "3.13.3"
+uv = "0.6.14"
+
+[env]
+_.python.venv = { path = ".venv", create = true, uv_create_args = ['--seed'] }
+
+[tasks.install]
+description = "Install dependencies"
+alias = "i"
+run = "uv pip install -r requirements.txt"
+
+[tasks.comms]
+description = "Process comms"
+depends = ["install"]
+run = "python comms.py"
+
+[tasks.dedup]
+description = "Deduplicate files (POTENTIALLY DESTRUCTIVE, BACKUP FIRST)"
+depends = ["install"]
+run = "python dedup.py"
+
+[tasks.embed_notes]
+description = "Embed notes"
+depends = ["install"]
+run = "python dedup.py"
+
+[tasks.last_contact]
+description = "Last contact with someone"
+depends = ["install"]
+run = "python last_contact.py"
+
+[tasks.md_birthdays]
+description = "Generate a MD calendar of birthdays"
+depends = ["install"]
+run = "python md_birthdays.py"
+
+[tasks.md_body]
+description = "Generate a MD calendar of birthdays"
+depends = ["install"]
+run = "python md_birthdays.py"
+
+[tasks.most_contacted]
+description = "Most contacted people"
+depends = ["install"]
+run = "python most_contacted.py"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+html2text==2025.4.15
+markdown==3.8
+markdown-it-py==3.0.0
+mdurl==0.1.2
+pip==25.0.1
+pygments==2.19.1
+rich==14.0.0


### PR DESCRIPTION
Thanks for sharing this! 

I'm trying to use the various scripts in here and I'm finding that most of them require "person" to be imported from the "../hal" directory, which I don't seem to see on your GitHub account. Is that something that you are still working on importing into this directory or making as a separate library?

I've added a tool called [mise](https://mise.jdx.dev/) which help to manage tool versions for Python and other tools, which then manages the Python version, as well as [uv](https://astral.sh/blog/uv-unified-python-packaging) which is an all-inclusive Python project tool. Having all that setup allows for an isolated Python virtual environment that has the dependendcies in `requirements.yaml` installed automatically when you run `mise run <command>`. I've found this tooling very helpful for keeping the towering stack of tools for all my different projects isolated from each other so I don't end up with weird conflicts in my development environment. I hope that you find it helpful!
